### PR TITLE
Initialize LLVM AMDGPU Target

### DIFF
--- a/src/driver/AmdCompiler.cpp
+++ b/src/driver/AmdCompiler.cpp
@@ -338,6 +338,7 @@ AMDGPUCompiler::AMDGPUCompiler(const std::string& llvmBin_)
     debug(false),
     inprocess(true)
 {
+  LLVMInitializeAMDGPUTarget();
   LLVMInitializeAMDGPUTargetInfo();
   LLVMInitializeAMDGPUTargetMC();
   LLVMInitializeAMDGPUDisassembler();


### PR DESCRIPTION
Without this initialization in-process compilation unable to create
a target machine and optimize bitcode properly.