### PR TITLE
in-process is switched back on.

### DIFF
--- a/src/driver/AmdCompiler.cpp
+++ b/src/driver/AmdCompiler.cpp
@@ -337,7 +337,7 @@ bool AMDGPUCompiler::IsInProcess()
 {
   const char* in_process_env = getenv("AMD_OCL_IN_PROCESS");
   if (in_process_env) {
-    if (std::string(in_process_env) == "1")
+    if (in_process_env[0] != '0')
       return true;
     else
       return false;

--- a/src/driver/AmdCompiler.h
+++ b/src/driver/AmdCompiler.h
@@ -237,6 +237,11 @@ public:
   * Change compilation mode (In-process compilation/spawn compilation processes)
   */
   virtual void SetInProcess(bool binprocess = true) = 0;
+
+  /*
+  * Checks whether compilation is in-process or not.
+  */
+  virtual bool IsInProcess() = 0;
 };
 
 /*


### PR DESCRIPTION
export AMD_OCL_IN_PROCESS=0 to switch off.
export AMD_OCL_IN_PROCESS=1 or unset AMD_OCL_IN_PROCESS to switch back on.