### PR TITLE
changes for opencl-rocm tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,24 +2,24 @@
 ##
 ## The University of Illinois/NCSA
 ## Open Source License (NCSA)
-## 
+##
 ## Copyright (c) 2016, Advanced Micro Devices, Inc. All rights reserved.
-## 
+##
 ## Developed by:
-## 
+##
 ##                 AMD Research and AMD HSA Software Development
-## 
+##
 ##                 Advanced Micro Devices, Inc.
-## 
+##
 ##                 www.amd.com
-## 
+##
 ## Permission is hereby granted, free of charge, to any person obtaining a copy
 ## of this software and associated documentation files (the "Software"), to
 ## deal with the Software without restriction, including without limitation
 ## the rights to use, copy, modify, merge, publish, distribute, sublicense,
 ## and#or sell copies of the Software, and to permit persons to whom the
 ## Software is furnished to do so, subject to the following conditions:
-## 
+##
 ##  - Redistributions of source code must retain the above copyright notice,
 ##    this list of conditions and the following disclaimers.
 ##  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 ##    nor the names of its contributors may be used to endorse or promote
 ##    products derived from this Software without specific prior written
 ##    permission.
-## 
+##
 ## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 ## IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 ## FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -56,6 +56,11 @@ find_package(LLVM REQUIRED PATHS ${LLVM_DIR} "/opt/rocm/llvm" NO_DEFAULT_PATH)
 
 list(APPEND CMAKE_MODULE_PATH ${LLVM_CMAKE_DIR})
 include(AddLLVM)
+else()
+include_directories(${CMAKE_SOURCE_DIR}/compiler/llvm/tools/clang/include)
+include_directories(${CMAKE_BINARY_DIR}/compiler/llvm/tools/clang/include)
+include_directories(${CMAKE_SOURCE_DIR}/compiler/llvm/lib/Target/AMDGPU)
+include_directories(${CMAKE_BINARY_DIR}/compiler/llvm/lib/Target/AMDGPU)
 endif()
 
 option(GENERIC_IS_ZERO "Teach LLVM/Clang that generic address space IS address space 0 for AMDGPU target" OFF)

--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -2,24 +2,24 @@
 ##
 ## The University of Illinois/NCSA
 ## Open Source License (NCSA)
-## 
+##
 ## Copyright (c) 2016, Advanced Micro Devices, Inc. All rights reserved.
-## 
+##
 ## Developed by:
-## 
+##
 ##                 AMD Research and AMD HSA Software Development
-## 
+##
 ##                 Advanced Micro Devices, Inc.
-## 
+##
 ##                 www.amd.com
-## 
+##
 ## Permission is hereby granted, free of charge, to any person obtaining a copy
 ## of this software and associated documentation files (the "Software"), to
 ## deal with the Software without restriction, including without limitation
 ## the rights to use, copy, modify, merge, publish, distribute, sublicense,
 ## and#or sell copies of the Software, and to permit persons to whom the
 ## Software is furnished to do so, subject to the following conditions:
-## 
+##
 ##  - Redistributions of source code must retain the above copyright notice,
 ##    this list of conditions and the following disclaimers.
 ##  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 ##    nor the names of its contributors may be used to endorse or promote
 ##    products derived from this Software without specific prior written
 ##    permission.
-## 
+##
 ## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 ## IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 ## FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -45,8 +45,6 @@ file(GLOB sources
   ${CMAKE_CURRENT_SOURCE_DIR}/*.h
 )
 
-include_directories(${LLVM_INCLUDE_DIRS})
-include_directories(${LLVM_INCLUDE_DIRS}/llvm/Target/AMDGPU)
 include_directories(${LLVM_INCLUDE_DIR})
 include_directories(${LLVM_INCLUDE_DIR}/llvm/Target/AMDGPU)
 
@@ -67,6 +65,7 @@ llvm_map_components_to_libnames(llvm_libs
   Core
   Option
   Support
+  AMDGPUCodeGen
   )
 
 if (WIN32)


### PR DESCRIPTION
1. added explicit dependency on AMDGPUCodeGen library
2. added explicit include directories fot AMDGPU target headers
3. removed redundant include dirs
4. removed trailing spaces