### PR TITLE
[in-process] In-process linkage.

### DIFF
--- a/src/driver/AmdCompiler.cpp
+++ b/src/driver/AmdCompiler.cpp
@@ -354,7 +354,7 @@ AMDGPUCompiler::AMDGPUCompiler(const std::string& llvmBin_)
     llvmLinkExe(llvmBin + "/llvm-link"),
     compilerTempDir(0),
     debug(false),
-    inprocess(true)
+    inprocess(false)
 {
   LLVMInitializeAMDGPUTarget();
   LLVMInitializeAMDGPUTargetInfo();

--- a/src/driver/AmdCompiler.h
+++ b/src/driver/AmdCompiler.h
@@ -242,6 +242,10 @@ public:
   * Checks whether compilation is in-process or not.
   */
   virtual bool IsInProcess() = 0;
+  /*
+  * Checks whether linkage is in-process or not.
+  */
+  virtual bool IsLinkInProcess() = 0;
 };
 
 /*


### PR DESCRIPTION
+ Switched on by default.
+ In-process compilation is switched off for now (due to https://github.com/RadeonOpenCompute/ROCm-OpenCL-Driver/issues/13).
+ Temporary env var is added (till in-process compilation is switched off):

  export AMD_OCL_LINK_IN_PROCESS=0 to switch off.
  export AMD_OCL_LINK_IN_PROCESS=1 or unset AMD_OCL_LINK_IN_PROCESS to switch back on.

+ Testing done:
  ocl_conformance 1.2: api, atomics, basic, buffers, commonfns, compiler