### PR TITLE
[in-process] [#22] [fix] Setting options to its default values.

### DIFF
--- a/src/driver/AmdCompiler.cpp
+++ b/src/driver/AmdCompiler.cpp
@@ -415,16 +415,12 @@ bool AMDGPUCompiler::ParseLLVMOptions(const CompilerInstance& clang)
 void AMDGPUCompiler::ResetOptionsToDefault()
 {
   cl::ResetAllOptionOccurrences();
-  // ToDo: uncomment after implementing llvm::cl::Option::setDefault()
-  /*
   for (auto SC : cl::getRegisteredSubcommands()) {
     for (auto &OM : SC->OptionsMap) {
       cl::Option *O = OM.second;
-      // missing functionality in Clang's CommandLine.h
       O->setDefault();
     }
   }
-  */
 }
 
 bool AMDGPUCompiler::PrepareCompiler(CompilerInstance& clang, const Command& job)


### PR DESCRIPTION
Feature in LLVM: https://reviews.llvm.org/rL311887

[Support][CommandLine] Add cl::Option::setDefault()

Add abstract virtual method setDefault() to class Option and implement it in its inheritors in order to be able to set all the options to its default values in user's code without actually knowing all these options.

Testing: ocl conformance 1.2 api, atomics, basic, buffers, commonfns, compiler, vec_align (with AMD_OCL_IN_PROCESS=1)