### PR TITLE
Remove workaround for the bug in lld with -Map file.

### DIFF
--- a/src/driver/AmdCompiler.cpp
+++ b/src/driver/AmdCompiler.cpp
@@ -756,10 +756,6 @@ bool AMDGPUCompiler::CompileAndLinkExecutable(Data* input, Data* output, const s
 {
   std::vector<const char*> args;
   AddCommonArgs(args);
-  File* mapFile = NewTempFile(DT_MAP, "", CompilerTempDir());
-  std::string smap = "-Wl,-Map=";
-  smap.append(mapFile->Name().c_str());
-  args.push_back(smap.c_str());
   FileReference* inputFile = ToInputFile(input, CompilerTempDir());
   args.push_back(inputFile->Name().c_str());
   File* outputFile = ToOutputFile(output, CompilerTempDir());


### PR DESCRIPTION
[Workaround]
https://github.com/RadeonOpenCompute/ROCm-OpenCL-Driver/commit/4f3dabb762bca9cb6c8803b8f895a45175558a78

[Reason]
Already fixed in lld: https://llvm.org/svn/llvm-project/lld/trunk@301423