### PR TITLE
[#26] Debug output for different compilation phases

### DIFF
--- a/src/driver/AmdCompiler.cpp
+++ b/src/driver/AmdCompiler.cpp
@@ -489,7 +489,7 @@ LogLevel AMDGPUCompiler::GetLogLevel()
     ss >> ll;
     switch (ll) {
       default:
-      case LL_DUMB: return LL_DUMB;
+      case LL_QUIET: return LL_QUIET;
       case LL_ERRORS: return LL_ERRORS;
       case LL_LLVM_ONLY: return LL_LLVM_ONLY;
       case LL_VERBOSE: return LL_VERBOSE;
@@ -501,7 +501,7 @@ LogLevel AMDGPUCompiler::GetLogLevel()
 const std::string& AMDGPUCompiler::Output()
 {
   output = {};
-  if (GetLogLevel() > LL_DUMB) { OS.flush(); }
+  if (GetLogLevel() > LL_QUIET) { OS.flush(); }
   return output;
 }
 
@@ -849,7 +849,7 @@ bool AMDGPUCompiler::CompileAndLinkExecutable(Data* input, Data* output, const s
           if (!PrepareCompiler(Clang, J)) { return Return(false); }
           // Action Backend_EmitObj
           std::unique_ptr<CodeGenAction> Act(new EmitObjAction());
-          if (!Act.get()) { return false; }
+          if (!Act.get()) { return Return(false); }
           if (!Clang.ExecuteAction(*Act)) { return Return(false); }
         }
         else if (i == 2 && sJobName == "amdgpu::Linker") {

--- a/src/driver/AmdCompiler.h
+++ b/src/driver/AmdCompiler.h
@@ -22,6 +22,13 @@ enum DataType {
   DT_INTERNAL,
 };
 
+enum LogLevel {
+  LL_DUMB = 0,
+  LL_ERRORS,
+  LL_LLVM_ONLY,
+  LL_VERBOSE,
+};
+
 class FileReference;
 class File;
 class Compiler;
@@ -148,7 +155,7 @@ public:
   /*
    * Return output of this compiler.
    */
-  virtual std::string Output() = 0;
+  virtual const std::string& Output() = 0;
 
   /*
    * Create new FileReference with given type and pointing to file with given name.
@@ -242,10 +249,26 @@ public:
   * Checks whether compilation is in-process or not.
   */
   virtual bool IsInProcess() = 0;
+
   /*
   * Checks whether linkage is in-process or not.
   */
   virtual bool IsLinkInProcess() = 0;
+
+  /*
+  * Checks whether to print compiler's log to stout or not.
+  */
+  virtual bool IsPrintLog() = 0;
+
+  /*
+  * Sets logging level.
+  */
+  virtual void SetLogLevel(LogLevel ll) = 0;
+
+  /*
+  * Gets logging level.
+  */
+  virtual LogLevel GetLogLevel() = 0;
 };
 
 /*

--- a/src/driver/AmdCompiler.h
+++ b/src/driver/AmdCompiler.h
@@ -23,7 +23,7 @@ enum DataType {
 };
 
 enum LogLevel {
-  LL_DUMB = 0,
+  LL_QUIET = 0,
   LL_ERRORS,
   LL_LLVM_ONLY,
   LL_VERBOSE,


### PR DESCRIPTION
Implements [[#26](https://github.com/RadeonOpenCompute/ROCm-OpenCL-Driver/issues/26)] feature.

To enable output to std::cout:
export AMD_OCL_PRINT_LOG=1
0 - is default

To set logging level:
export AMD_OCL_LOG_LEVEL= { 0 | 1 | 2 | 3 }
where LL_DUMB = 0, LL_ERRORS = 1, LL_LLVM_ONLY = 2, LL_VERBOSE = 3; 1 – is default

Testing done: OpenCL conformance 1.2 compiler (both via driver API and in-process).