### PR TITLE
[in-process] Initialize AsmParser

### DIFF
--- a/src/driver/AmdCompiler.cpp
+++ b/src/driver/AmdCompiler.cpp
@@ -523,6 +523,7 @@ AMDGPUCompiler::AMDGPUCompiler(const std::string& llvmBin_)
   LLVMInitializeAMDGPUTargetMC();
   LLVMInitializeAMDGPUDisassembler();
   if (IsInProcess()) {
+    LLVMInitializeAMDGPUAsmParser();
     LLVMInitializeAMDGPUAsmPrinter();
   }
 }

--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -66,6 +66,7 @@ llvm_map_components_to_libnames(llvm_libs
   Option
   Support
   AMDGPUCodeGen
+  AMDGPUAsmParser
   )
 
 if (WIN32)


### PR DESCRIPTION
Fixes inline asm which was broken by enabling in process compilation.