### PR TITLE
[in-process] Enabling lld in-process

### DIFF
--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -47,6 +47,7 @@ file(GLOB sources
 
 include_directories(${LLVM_INCLUDE_DIR})
 include_directories(${LLVM_INCLUDE_DIR}/llvm/Target/AMDGPU)
+include_directories(${LLD_INCLUDE_DIR})
 
 link_directories(${LLVM_LIBRARY_DIRS})
 add_library(opencl_driver ${sources})
@@ -80,6 +81,9 @@ target_link_libraries(opencl_driver
   clangLex
   clangBasic
   clangCodeGen
+  lldELF
+  lldCore
+  LLVMDebugInfoDWARF
 )
 target_link_libraries(opencl_driver ${llvm_libs})
 target_include_directories(opencl_driver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Reasons:
1. [[#19](https://github.com/RadeonOpenCompute/ROCm-OpenCL-Driver/issues/19)] "Using statically linked lld leads to segmentation fault" is fixed by [rL314108](https://reviews.llvm.org/rL314108)
2. Testing is done: ocl conformance 1.2