### PR TITLE
Revert "[in-process] Enabling lld in-process"

### DIFF
--- a/src/driver/AmdCompiler.cpp
+++ b/src/driver/AmdCompiler.cpp
@@ -54,7 +54,6 @@
 #include "llvm/Linker/Linker.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
-#include "lld/Driver/Driver.h"
 
 #include <sstream>
 #include <iostream>
@@ -837,14 +836,11 @@ bool AMDGPUCompiler::CompileAndLinkExecutable(Data* input, Data* output, const s
           if (!Clang.ExecuteAction(*Act)) { return Return(false); }
         }
         else if (i == 2 && sJobName == "amdgpu::Linker") {
-          driver::ArgStringList Args(J.getArguments());
-          Args.insert(Args.begin(),"");
-          ArrayRef<const char*> ArgRefs = llvm::makeArrayRef(Args);
-          static std::mutex m_screen;
-          m_screen.lock();
-          bool lldRet = lld::elf::link(ArgRefs, false, OS);
-          m_screen.unlock();
-          if (!lldRet) { return Return(false); }
+          // lld fork
+          if (!InvokeTool(J.getArguments(), llvmBin + +"/ld.lld")) { return Return(false); }
+          /* lld statically linked */
+          //ArrayRef<const char *> ArgRefs = llvm::makeArrayRef(J.getArguments());
+          //if (!lld::elf::link(ArgRefs, false)) { return Return(false); }
         }
         else { return Return(false); }
         i++;

--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -47,7 +47,6 @@ file(GLOB sources
 
 include_directories(${LLVM_INCLUDE_DIR})
 include_directories(${LLVM_INCLUDE_DIR}/llvm/Target/AMDGPU)
-include_directories(${LLD_INCLUDE_DIR})
 
 link_directories(${LLVM_LIBRARY_DIRS})
 add_library(opencl_driver ${sources})
@@ -81,9 +80,6 @@ target_link_libraries(opencl_driver
   clangLex
   clangBasic
   clangCodeGen
-  lldELF
-  lldCore
-  LLVMDebugInfoDWARF
 )
 target_link_libraries(opencl_driver ${llvm_libs})
 target_include_directories(opencl_driver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Reverts RadeonOpenCompute/ROCm-OpenCL-Driver#46 due to build failure.

lld includes are not being found by cmake.