### PR TITLE
[in-process] Eliminate separate ability of in-process linking

### DIFF
--- a/src/driver/AmdCompiler.cpp
+++ b/src/driver/AmdCompiler.cpp
@@ -281,7 +281,6 @@ private:
   std::string llvmLinkExe;
   File* compilerTempDir;
   bool inprocess;
-  bool linkinprocess;
   LogLevel logLevel;
   bool printlog;
   bool keeptmp;
@@ -345,8 +344,6 @@ public:
   void SetInProcess(bool binprocess = true) override;
 
   bool IsInProcess() override { return IsVar("AMD_OCL_IN_PROCESS", inprocess); }
-
-  bool IsLinkInProcess() override { return IsVar("AMD_OCL_LINK_IN_PROCESS", linkinprocess); }
 
   void SetKeepTmp(bool bkeeptmp = true) override { keeptmp = bkeeptmp; }
 
@@ -536,7 +533,6 @@ AMDGPUCompiler::AMDGPUCompiler(const std::string& llvmBin_)
     llvmLinkExe(llvmBin + "/llvm-link"),
     compilerTempDir(0),
     inprocess(true),
-    linkinprocess(true),
     logLevel(LL_ERRORS),
     printlog(false),
     keeptmp(false) {
@@ -742,8 +738,7 @@ bool AMDGPUCompiler::EmitLinkerError(LLVMContext &context, const Twine &message)
 }
 
 bool AMDGPUCompiler::LinkLLVMBitcode(const std::vector<Data*>& inputs, Data* output, const std::vector<std::string>& options) {
-  bool bIsInProcess = IsInProcess() || IsLinkInProcess();
-  PrintPhase("LinkLLVMBitcode", bIsInProcess);
+  PrintPhase("LinkLLVMBitcode", IsInProcess());
   std::vector<const char*> args;
   for (Data* input : inputs) {
     FileReference* inputFile = ToInputFile(input, CompilerTempDir());
@@ -753,7 +748,7 @@ bool AMDGPUCompiler::LinkLLVMBitcode(const std::vector<Data*>& inputs, Data* out
   if (!options.empty()) {
     std::vector<const char*> argv;
     for (auto option : options) {
-      if (bIsInProcess) {
+      if (IsInProcess()) {
         argv.push_back("");
         argv.push_back(option.c_str());
         if (!cl::ParseCommandLineOptions(argv.size(), &argv[0], "llvm linker")) {
@@ -765,12 +760,12 @@ bool AMDGPUCompiler::LinkLLVMBitcode(const std::vector<Data*>& inputs, Data* out
       }
     }
   }
-  if (!bIsInProcess) {
+  if (!IsInProcess()) {
     args.push_back("-o");
     args.push_back(outputFile->Name().c_str());
   }
-  if (bIsInProcess) {
-    PrintOptions(args, "llvm linker", bIsInProcess);
+  if (IsInProcess()) {
+    PrintOptions(args, "llvm linker", IsInProcess());
     LLVMContext context;
     context.setDiagnosticHandler(
         llvm::make_unique<AMDGPUCompilerDiagnosticHandler>(this), true);

--- a/src/driver/AmdCompiler.h
+++ b/src/driver/AmdCompiler.h
@@ -255,11 +255,6 @@ public:
   virtual bool IsInProcess() = 0;
 
   /*
-  * Checks whether linkage is in-process or not.
-  */
-  virtual bool IsLinkInProcess() = 0;
-
-  /*
   * Enables or disables keeping compiler's temporary files.
   */
   virtual void SetKeepTmp(bool bkeeptmp = true) = 0;


### PR DESCRIPTION
+ AMD_OCL_LINK_IN_PROCESS eliminated as well as no longer needed.
+ To manage in-process ability for all llvm tools’ invocation (clang, llvm-link, lld) the only environment var. AMD_OCL_IN_PROCESS={0|1} might be used.