### PR TITLE
Remove configurable triple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,13 +60,6 @@ else()
 include_directories(${ROCM_OCL_INCLUDES})
 endif()
 
-option(GENERIC_IS_ZERO "Teach LLVM/Clang that generic address space IS address space 0 for AMDGPU target" OFF)
-if (GENERIC_IS_ZERO)
-  add_definitions(-DAMDGCN_TRIPLE=amdgcn-amd-amdhsa-amdgizcl)
-else (GENERIC_IS_ZERO)
-  add_definitions(-DAMDGCN_TRIPLE=amdgcn-amd-amdhsa-opencl)
-endif (GENERIC_IS_ZERO)
-
 if(UNIX)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-rtti -Wall")
   add_definitions(-D__STDC_LIMIT_MACROS)

--- a/src/driver/AmdCompiler.cpp
+++ b/src/driver/AmdCompiler.cpp
@@ -93,9 +93,7 @@
 
 #define QUOTE(s) #s
 #define STRING(s) QUOTE(s)
-#ifndef AMDGCN_TRIPLE
-#define AMDGCN_TRIPLE amdgcn-amd-amdhsa-opencl
-#endif
+#define AMDGCN_TRIPLE amdgcn-amd-amdhsa
 
 using namespace llvm;
 using namespace llvm::object;


### PR DESCRIPTION
There is only one triple to use now since
the giz option is gone.