### PR TITLE
Fix #76: [cmake] Incorrect gtest lib directory detection

### DIFF
--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -63,7 +63,7 @@ ExternalProject_Add(
 ExternalProject_Get_Property(googletest source_dir)
 include_directories(${source_dir}/googletest/include)
 ExternalProject_Get_Property(googletest binary_dir)
-link_directories(${binary_dir}/googletest)
+link_directories(${binary_dir}/lib)
 
 #include(${GTEST_INCLUDE_DIRS})
 file(GLOB sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)


### PR DESCRIPTION
Fixes bug #76 in cmake build scripts. Changes gtest subfolder searched for libs from `googletest` to `libs` to correctly match actual location.