### PR TITLE
Use GNUInstallDirs to install to standard locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@
 
 cmake_minimum_required(VERSION 2.8)
 
+## Include common cmake modules
+include ( GNUInstallDirs )
+
 # Build ROCm-OpenCL-Driver with ccache if the package is present.
 set(ROCM_OPENCL_DRIVER_CCACHE_BUILD OFF CACHE BOOL "Set to ON for a ccache enabled build")
 if(ROCM_OPENCL_DRIVER_CCACHE_BUILD)

--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -90,4 +90,4 @@ target_link_libraries(opencl_driver
 target_link_libraries(opencl_driver ${llvm_libs})
 target_include_directories(opencl_driver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-install(TARGETS opencl_driver DESTINATION lib)
+install(TARGETS opencl_driver DESTINATION ${CMAKE_INSTALL_LIBDIR} )

--- a/src/roc-cl/CMakeLists.txt
+++ b/src/roc-cl/CMakeLists.txt
@@ -54,4 +54,4 @@ link_directories(${LLVM_LIBRARY_DIRS})
 add_executable(roc-cl ${sources})
 target_link_libraries(roc-cl opencl_driver)
 
-install(TARGETS roc-cl RUNTIME DESTINATION bin)
+install(TARGETS roc-cl RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )


### PR DESCRIPTION
Some distributions require 64 bit libraries to be installed to lib64, for example.
Using GNUInstallDirs ensures that files are installed to the expected locations.

See also https://github.com/RadeonOpenCompute/ROCR-Runtime/pull/51 and work already in https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/commit/fd26b7fa5c00cca198197ba2b73d7422d0251f47