### PR TITLE
[cmake] Install AmdCompiler.h header

### DIFF
--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -91,3 +91,4 @@ target_link_libraries(opencl_driver ${llvm_libs})
 target_include_directories(opencl_driver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 install(TARGETS opencl_driver DESTINATION ${CMAKE_INSTALL_LIBDIR} )
+install(FILES AmdCompiler.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
ROCm-OpenCL-Runtime uses AmdCompiler.h so it should be installed to the system and made available for use