### PR TITLE
[cmake] Include more link libraries

### DIFF
--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -60,9 +60,13 @@ llvm_map_components_to_libnames(llvm_libs
   AllTargetsDescs
   AllTargetsDisassemblers
   AllTargetsInfos
+  BitWriter
   CodeGen
+  IRReader
+  Linker
   MC
   MCDisassembler
+  MCParser
   Object
   Symbolize
   Core
@@ -83,6 +87,7 @@ target_link_libraries(opencl_driver
   clangLex
   clangBasic
   clangCodeGen
+  clangSerialization
   lldELF
   lldCore
   LLVMDebugInfoDWARF


### PR DESCRIPTION
This is required to get dev-libs/rocm-opencl-driver-2.7.0 compiling for me on Gentoo

I think it might be related to using -Wl,--as-needed in my link flags globally